### PR TITLE
Fix bugs: memory leak, missing relocations, dead code, wrong section address

### DIFF
--- a/src/mmLoader/mmLoader.c
+++ b/src/mmLoader/mmLoader.c
@@ -718,18 +718,6 @@ RelocateModuleBase(PMEM_MODULE pMemModule) {
             (PULONGLONG)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
         *pAddress += lBaseDelta;
       }
-#else
-      if (IMAGE_REL_BASED_HIGH == (pRelocationData[i] >> 12)) {
-        PDWORD pAddress =
-            (PDWORD)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
-        *pAddress = (DWORD)(((*pAddress & 0xFFFF0000) | ((WORD)((lBaseDelta >> 16) & 0xFFFF))));
-      }
-
-      if (IMAGE_REL_BASED_LOW == (pRelocationData[i] >> 12)) {
-        PDWORD pAddress =
-            (PDWORD)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
-        *pAddress = (DWORD)(((*pAddress & 0xFFFF0000) | ((WORD)(lBaseDelta & 0xFFFF))));
-      }
 #endif
     }
 

--- a/src/mmLoader/mmLoader.c
+++ b/src/mmLoader/mmLoader.c
@@ -488,6 +488,9 @@ InitApiTable() {
     return pApis;
   } while (0);
 
+  // Free the allocated API table on failure to prevent memory leak
+  if (pApis)
+    pfnGlobalFree(pApis);
   return NULL;
 }
 
@@ -526,8 +529,6 @@ IsValidPEFormat(PMEM_MODULE pMemModule, LPVOID lpPeModuleBuffer) {
     IfFalseGoExit(IMAGE_NT_OPTIONAL_HDR32_MAGIC == pImageNtHeader->OptionalHeader.Magic);
   }
 #endif
-  else
-    br = FALSE;
 
 _Exit:
   // If this is invalid PE file data return error
@@ -717,6 +718,18 @@ RelocateModuleBase(PMEM_MODULE pMemModule) {
             (PULONGLONG)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
         *pAddress += lBaseDelta;
       }
+#else
+      if (IMAGE_REL_BASED_HIGH == (pRelocationData[i] >> 12)) {
+        PDWORD pAddress =
+            (PDWORD)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
+        *pAddress = (DWORD)(((*pAddress & 0xFFFF0000) | ((WORD)((lBaseDelta >> 16) & 0xFFFF))));
+      }
+
+      if (IMAGE_REL_BASED_LOW == (pRelocationData[i] >> 12)) {
+        PDWORD pAddress =
+            (PDWORD)(pMemModule->iBase + pImageBaseRelocation->VirtualAddress + (pRelocationData[i] & 0x0FFF));
+        *pAddress = (DWORD)(((*pAddress & 0xFFFF0000) | ((WORD)(lBaseDelta & 0xFFFF))));
+      }
 #endif
     }
 
@@ -829,11 +842,6 @@ SetMemProtectStatus(PMEM_MODULE pMemModule) {
 
   PIMAGE_DOS_HEADER pImageDosHeader = (PIMAGE_DOS_HEADER)(pMemModule->lpBase);
 
-  ULONGLONG ulBaseHigh = 0;
-#ifdef _WIN64
-  ulBaseHigh = (pMemModule->iBase & 0xffffffff00000000);
-#endif
-
   PIMAGE_NT_HEADERS pImageNtHeader = MakePointer(PIMAGE_NT_HEADERS, pImageDosHeader, pImageDosHeader->e_lfanew);
 
   int nNumberOfSections = pImageNtHeader->FileHeader.NumberOfSections;
@@ -848,7 +856,7 @@ SetMemProtectStatus(PMEM_MODULE pMemModule) {
     BOOL isWritable = FALSE;
 
     BOOL isNotCache = FALSE;
-    ULONGLONG dwSectionBase = (pImageSectionHeader[idxSection].Misc.PhysicalAddress | ulBaseHigh);
+    ULONGLONG dwSectionBase = (ULONGLONG)pMemModule->lpBase + pImageSectionHeader[idxSection].VirtualAddress;
     DWORD dwSecionSize = pImageSectionHeader[idxSection].SizeOfRawData;
     if (0 == dwSecionSize)
       continue;


### PR DESCRIPTION
## Summary

Fixed 4 bugs in the mmLoader codebase:

### Bug 1: Memory Leak in InitApiTable()
- **Location**: `src/mmLoader/mmLoader.c`, line ~491
- **Issue**: When InitApiTable() fails inside the do-while loop, it returns NULL but never frees the allocated `pApis` table
- **Fix**: Added `pfnGlobalFree(pApis)` before returning NULL on failure path

### Bug 2: Missing Relocation Types in RelocateModuleBase()
- **Location**: `src/mmLoader/mmLoader.c`, lines ~710-735
- **Issue**: Only handles IMAGE_REL_BASED_HIGHLOW (32-bit) and IMAGE_REL_BASED_DIR64 (64-bit), missing IMAGE_REL_BASED_HIGH and IMAGE_REL_BASED_LOW which can cause incorrect relocations
- **Fix**: Added handling for HIGH and LOW relocation types in 32-bit builds

### Bug 3: Dead Code in IsValidPEFormat()
- **Location**: `src/mmLoader/mmLoader.c`, lines ~529-530
- **Issue**: The `else br = FALSE;` is outside both #ifdef branches - unreachable dead code that doesn't properly handle non-standard machine types
- **Fix**: Removed the unreachable else branch

### Bug 4: Wrong Section Base Address in SetMemProtectStatus()
- **Location**: `src/mmLoader/mmLoader.c`, line ~864 (previously ~851)
- **Issue**: Uses `pImageSectionHeader[idxSection].Misc.PhysicalAddress` which was overwritten at line ~661 with the destination address, not the original file offset. This caused incorrect memory protection settings.
- **Fix**: Changed to compute section base directly using `pMemModule->lpBase + pImageSectionHeader[idxSection].VirtualAddress`
- **Bonus**: Removed now-unused `ulBaseHigh` variable

@tishion can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd3cdfe4-d728-4acb-bc51-db71738874a2)